### PR TITLE
Replace pyfits with astropy.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Python package for the K2 systematics correction using Gaussian processes.
 
  - NumPy
  - SciPy
- - PyFITS
+ - astropy
  - George
 
 ## Authors

--- a/bin/k2ginfo
+++ b/bin/k2ginfo
@@ -4,7 +4,7 @@
 from __future__ import division
 import sys
 import numpy as np
-import pyfits as pf
+import astropy.io.fits as pf
 import pandas as pd
 
 from os.path import join, abspath, basename, exists

--- a/bin/k2mastify
+++ b/bin/k2mastify
@@ -4,7 +4,7 @@ import logging
 import re
 
 import pandas as pd
-import pyfits as pf
+import astropy.io.fits as pf
 
 from argparse import ArgumentParser
 from datetime import datetime

--- a/bin/k2plot
+++ b/bin/k2plot
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import math as mt
 import numpy as np
-import pyfits as pf
+import astropy.io.fits as pf
 import pandas as pd
 import seaborn as sb
 import matplotlib.pyplot as pl

--- a/bin/k2sc
+++ b/bin/k2sc
@@ -9,7 +9,7 @@ import logging
 import math as mt
 import numpy as np
 import scipy as sp
-import pyfits as pf
+import astropy.io.fits as pf
 import matplotlib.pyplot as pl
 
 try:

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(name='K2SC',
       package_dir={'k2sc':'src'},
       scripts=['bin/k2sc','bin/k2plot','bin/k2ginfo', 'bin/k2mastify'],
       packages=['k2sc'],
-      install_requires=["numpy"],
+      install_requires=["numpy", "astropy", "scipy", "george"],
       license='GPLv2',
       classifiers=[
           "Topic :: Scientific/Engineering",

--- a/src/k2io.py
+++ b/src/k2io.py
@@ -24,7 +24,7 @@
 import warnings
 import numpy as np
 import re
-import pyfits as pf
+import astropy.io.fits as pf
 from os.path import basename, splitext
 from datetime import datetime
 from collections import namedtuple

--- a/tests/opdetection.py
+++ b/tests/opdetection.py
@@ -4,7 +4,7 @@ from matplotlib.pyplot import *
 from argparse import ArgumentParser
 
 import math as mt
-import pyfits as pf
+import astropy.io.fits as pf
 rc('figure', figsize=(14,6))
 
 from k2sc.k2io import MASTReader


### PR DESCRIPTION
I hope you don't mind the pull request, but I thought I would replace the now [deprecated](http://www.stsci.edu/institute/software_hardware/pyfits) pyfits with the better maintained version in astropy.

I also added all the runtime dependancies to the setup.py file, but I can remove those if you would rather have people install them themselves.